### PR TITLE
Catch timeout exception when updating and pushing changes for a site column

### DIFF
--- a/Core/OfficeDevPnP.Core.Tests/Authentication/AuthenticationTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Authentication/AuthenticationTests.cs
@@ -34,6 +34,11 @@ namespace OfficeDevPnP.Core.Tests.Authentication
         }
         #endregion
 
+        /// <summary>
+        /// Important: the Azure AD you're using here needs to be consented first, otherwise you'll get an access denied.
+        /// Consenting can be done by taking this URL and replacing the client_id parameter value with yours: https://login.microsoftonline.com/common/oauth2/authorize?state=e82ea723-7112-472c-94d4-6e66c0ca52b6&response_type=code+id_token&scope=openid&nonce=c328d2df-43d1-4e4d-a884-7cfb492beadc&client_id=b77caa50-d9ba-4b30-aad6-a40effa2ecd0&redirect_uri=https:%2f%2flocalhost:44304%2fHome%2f&resource=https:%2f%2fgraph.windows.net%2f&prompt=admin_consent&response_mode=form_post
+        /// To debug this catch the returned access token and look http://jwt.calebb.net/ to see if the token contains roles claims
+        /// </summary>
         [TestMethod]
         public void AzureADAuthFullControlPermissionTest()
         {

--- a/Core/OfficeDevPnP.Core.Tests/Framework/Functional/Validators/LocalizationValidator.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/Functional/Validators/LocalizationValidator.cs
@@ -69,7 +69,7 @@ namespace OfficeDevPnP.Core.Tests.Framework.Functional.Validators
             #endregion
 
             #region Navigation
-            if (isNoScriptSite && CanUseAcceptLanguageHeaderForLocalization(web))
+            if (!isNoScriptSite && CanUseAcceptLanguageHeaderForLocalization(web))
             {
                 isValid = ValidateStructuralNavigation(ptSource, sParser);
                 if (!isValid) return false;

--- a/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTermGroupsTests.cs
+++ b/Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTermGroupsTests.cs
@@ -53,10 +53,13 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                         termSet1.DeleteObject();
                         termSet2.DeleteObject();
 
+                        store.CommitAll();
+                        ctx.ExecuteQueryRetry();
+
                         if (_termGroupGuid != Guid.Empty)
                         {
                             var termGroup = store.GetGroup(_termGroupGuid);
-                            termGroup.DeleteObject(); 
+                            termGroup.DeleteObject();
                         }
                         store.CommitAll();
                         ctx.ExecuteQueryRetry();

--- a/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
+++ b/Core/OfficeDevPnP.Core/CoreResources.Designer.cs
@@ -1380,6 +1380,15 @@ namespace OfficeDevPnP.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Updating field {0} received a timeout when pushing changes to lists.
+        /// </summary>
+        internal static string Provisioning_ObjectHandlers_Fields_Updating_field__0__timeout {
+            get {
+                return ResourceManager.GetString("Provisioning_ObjectHandlers_Fields_Updating_field__0__timeout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Adding webpart &apos;{0}&apos; to page.
         /// </summary>
         internal static string Provisioning_ObjectHandlers_Files_Adding_webpart___0___to_page {

--- a/Core/OfficeDevPnP.Core/CoreResources.resx
+++ b/Core/OfficeDevPnP.Core/CoreResources.resx
@@ -1078,4 +1078,7 @@
   <data name="Provisioning_ObjectHandlers_Navigation_SkipProvisioning" xml:space="preserve">
     <value>Skip applying of navigation settings on NoScript sites.</value>
   </data>
+  <data name="Provisioning_ObjectHandlers_Fields_Updating_field__0__timeout" xml:space="preserve">
+    <value>Updating field {0} received a timeout when pushing changes to lists</value>
+  </data>
 </root>


### PR DESCRIPTION
This change fixes an issue where updating and pushing changes for a field, will result in a timeout exception if the field is a site column and the site column is used on many subsites and lists.